### PR TITLE
Feature : 학습 / 검증 태스크 통합

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Optional
+from transformers import TrainingArguments
 
 
 @dataclass
@@ -90,3 +91,26 @@ class DataTrainingArguments:
     use_faiss: bool = field(
         default=False, metadata={"help": "Whether to build with faiss"}
     )
+
+train_args = TrainingArguments(
+    do_train=True,
+    do_eval=True,
+    output_dir="./finetune/",
+    overwrite_output_dir=True,
+    evaluation_strategy="steps",
+    per_device_train_batch_size=32,
+    per_device_eval_batch_size=32,
+    gradient_accumulation_steps=2,
+    learning_rate=1e-5,
+    num_train_epochs=8,
+    warmup_ratio=0.1,
+    logging_strategy="steps",
+    logging_steps=100,
+    save_strategy="steps",
+    save_steps=200,
+    save_total_limit=1,
+    seed=42,
+    eval_steps=200,
+    metric_for_best_model="exact_match",
+    load_best_model_at_end=True,
+)

--- a/eval_reader.sh
+++ b/eval_reader.sh
@@ -3,6 +3,4 @@
 # 직접 finetune 한 모델의 결과가 있다면 --model_name_or_path 에 불러주기
 
 python train.py \
---model_name_or_path="./finetune/" \
---output_dir="./finetune_result" \
---do_eval
+--model_name_or_path="./finetune/"

--- a/predict_inference.sh
+++ b/predict_inference.sh
@@ -3,5 +3,5 @@
 python inference.py \
 --output_dir="./output" \
 --model_name_or_path="./finetune/" \
---dataset_name="../data/test_data" \
+--dataset_name="../data/test_dataset" \
 --do_predict

--- a/train_reader.sh
+++ b/train_reader.sh
@@ -1,5 +1,0 @@
-# 관련 문서를 뽑아낸 상황에서 정답을 찾는 모델을 훈련하는 쉘 스크립트
-
-python train.py \
---output_dir="./finetune/" \
---do_train


### PR DESCRIPTION
## TrainingArguments 분리
* TrainingArguments 관련 하이퍼 파라미터를 세팅할 겸 arguments.py 에 따로 분리해두었습니다.

## train_reader.sh 파일 삭제
* TrainingArguments 덕분에 필요없어졌습니다. 이제 학습은 `python train.py` 로 하시면 됩니다.

## 학습 시 출력되는 콘솔 정리
* 간단하게 출력되도로 logging level 을 손봤습니다.

## compute_metrics 수정
* 학습과 검증을 동시에 하기에 아래와 같이 수정했습니다

```python
def compute_metrics(p: EvalPrediction):
        result =  metric.compute(predictions=p.predictions, references=p.label_ids)
        result["eval_exact_match"] = result["exact_match"]
        del result["exact_match"]
        result["eval_f1"] = result["f1"]
        del result["f1"]
        return result
```

@addadda15 @hyoeun98 @inbeomi @junseok0408  리뷰 부탁드립니다!